### PR TITLE
Feature/misc improvements

### DIFF
--- a/scmap-preprocess-sce.R
+++ b/scmap-preprocess-sce.R
@@ -35,16 +35,34 @@ if(!file.exists(opt$input_object)){
 # read in the SCE object 
 SingleCellExperiment <- readRDS(opt$input_object)
 
-# un-sparse and log-transform counts
-if("normcounts" %in% names(assays(SingleCellExperiment))){
-    normcounts(SingleCellExperiment) <- as.matrix(normcounts(SingleCellExperiment))
-    logcounts(SingleCellExperiment) <- log2(normcounts(SingleCellExperiment) + 1)
-} else if("counts" %in% names(assays(SingleCellExperiment))) {
-    counts(SingleCellExperiment) <- as.matrix(counts(SingleCellExperiment))
-    logcounts(SingleCellExperiment) <- log2(counts(SingleCellExperiment) + 1)
-} else{
-    stop("Incrorrect assay names in SCE object")
-}  
+# Matrix-ify any e.g. sparse matrices in assays
+assays(SingleCellExperiment) <- lapply(assays(SingleCellExperiment), function(x){
+    if (! is.matrix(x)){
+        x <- as.matrix(x)
+    }
+    x
+})
+
+assay_names <- names(assays(SingleCellExperiment)
+
+# We need counts for dropout detection. If normcounts is present, just reassign those
+
+if (! 'counts' %in% assay_names){
+    if ( 'normcounts' %in% assay_names){
+        names(assays(sce))[names(assays(sce)) == 'normcounts'] <- 'counts'
+    }else{
+        stop("Neither 'counts' nor 'normcounts' are populated in input object, these are necessary for dropout rate calculations and I can't proceed without them")
+    }
+}
+
+# We need the logcounts() slot, so calculate it if it's not present
+if (! 'logcounts' %in% assay_names){
+    if("normcounts" %in% assay_names ){
+        logcounts(SingleCellExperiment) <- log2(normcounts(SingleCellExperiment) + 1)
+    } else if("counts" %in% names(assays(SingleCellExperiment))) {
+        logcounts(SingleCellExperiment) <- log2(counts(SingleCellExperiment) + 1)
+    } 
+}
 
 # use gene names as feature symbols
 rowData(SingleCellExperiment)$feature_symbol <- rownames(SingleCellExperiment)

--- a/scmap-preprocess-sce.R
+++ b/scmap-preprocess-sce.R
@@ -43,18 +43,18 @@ assays(SingleCellExperiment) <- lapply(assays(SingleCellExperiment), function(x)
     x
 })
 
-assay_names <- names(assays(SingleCellExperiment)
+assay_names <- names(assays(SingleCellExperiment))
 
 # We need counts for dropout detection. If normcounts is present, just reassign those
 
 if (! 'counts' %in% assay_names){
     if ( 'normcounts' %in% assay_names){
-        names(assays(sce))[names(assays(sce)) == 'normcounts'] <- 'counts'
+        names(assays(SingleCellExperiment))[names(assays(SingleCellExperiment)) == 'normcounts'] <- 'counts'
+        assay_names <- names(assays(SingleCellExperiment))
     }else{
-        stop("Neither 'counts' nor 'normcounts' are populated in input object, these are necessary for dropout rate calculations and I can't proceed without them")
+        stop("Neither 'counts' nor 'normcounts' are populated in input object. An unlogged matrix is necessary for dropout rate calculations and I can't proceed without one of these.")
     }
 }
-
 # We need the logcounts() slot, so calculate it if it's not present
 if (! 'logcounts' %in% assay_names){
     if("normcounts" %in% assay_names ){


### PR DESCRIPTION
This PR tweaks the handling of the assays in the single cell experiment object passed to scmap. Assays in SCE objects are conventionally:

 - counts (raw counts)
 - normcounts (normalised counts)
 - logcounts (log-transformed counts, usually derived from the normcounts)
 - plus some other flavours

The scmap tool expects that 'normcounts' and 'counts' are populated, the former being used for dropout detection. It will use 'logcounts' if there are no 'counts', but that will frequently not have 0s (due to +1s in transform), so seems like a silly idea.

We can move 'normcounts' to 'counts' if necessary, since zeros will normally be preserved, but we can't manage with just 'normcounts'. 'normcounts' should be preserved if it's supplied, but otherwise calculated from the 'counts' (or 'normcounts') slot.