### PR TITLE
Get std output (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a collection of R scripts to allow workflow-driven execution of differnt
 
 Currently wrapped scmap functions are described below. Each script has usage insructions available via --help, consult function documentation in scmap for further details.
 
-### Preprocess SCE object for scmap pipeline
+### Preprocess SCE object for scmap pipeline
 This script makes the necessary changes to the SCE object required by the scmap workflow, including 'un-sparsing' and log-normalising the expression matrix.    
 
 ```

--- a/README.md
+++ b/README.md
@@ -76,3 +76,15 @@ scmap-scmap-cell.R -i $index_cell_sce -p <input SingleCellExperiment in .rds for
     --closest-cells-text-file <csv file to store closest cells> \
     --closest-cells-similarities-text-file <csv file to store similarity values>
 ```
+
+### Get standard output for downstream processing and analysis as part of various workflows
+
+```
+scmap_get_std_output.R\
+            --predictions-file <Path to the predictions file in text format>\
+            --output-table <Path to the final output file in text format>\
+            --include-scores <Boolean: Should prediction scores be included in output? Default: FALSE>\
+            --sim-col-name <Column name of similarity scores>
+```
+
+

--- a/scmap-cli-post-install-tests.bats
+++ b/scmap-cli-post-install-tests.bats
@@ -107,3 +107,25 @@
     [ "$status" -eq 0 ]
     [ -f  "$closest_cells_similarities_text_file" ]
 }
+
+
+@test "Obtain standard output" {
+    if [ "$use_existing_outputs" = 'true' ] && [ -f "$scmap_output_tbl" ]; then
+        skip "$scmap_output_tbl exists and use_existing_outputs is set to 'true'"
+    fi
+
+    run rm -rf $scmap_output_tbl && scmap_get_std_output.R\
+                                        --predictions-file $closest_cells_clusters_csv\
+                                        --output-table $scmap_output_tbl\
+                                        --include-scores
+
+    echo "status = ${status}"
+    echo "output = ${output}"
+ 
+    [ "$status" -eq 0 ]
+    [ -f  "$scmap_output_tbl" ]
+
+}
+
+
+

--- a/scmap-cli-post-install-tests.sh
+++ b/scmap-cli-post-install-tests.sh
@@ -67,6 +67,7 @@ export closest_cells_text_file=$output_dir'/closest_cells.csv'
 export closest_cells_similarities_text_file=$output_dir'/closest_cells_similarities.csv'
 export closest_cells_clusters_sce=$output_dir'/closest_cells_clusters.rds'
 export closest_cells_clusters_csv=$output_dir'/closest_cells_clusters.csv'
+export scmap_output_tbl=$output_dir'/scmap_output_tbl.txt'
 
 ## Test parameters- would form config file in real workflow. DO NOT use these
 ## as default values without being sure what they mean.

--- a/scmap_get_std_output.R
+++ b/scmap_get_std_output.R
@@ -1,0 +1,49 @@
+#!/usr/bin/env Rscript
+suppressPackageStartupMessages(require(optparse))
+suppressPackageStartupMessages(require(workflowscriptscommon))
+
+### create final output in standard format
+option_list = list(
+    make_option(
+        c("-i", "--predictions-file"),
+        action = 'store',
+        default = NA,
+        type = 'character',
+        help = 'Path to the predictions file in text format'
+    ),
+    make_option(
+        c("-o", "--output-table"),
+        action = 'store',
+        default = NA,
+        type = 'character',
+        help = 'Path to the final output file in text format'
+    ), 
+    make_option(
+        c("-s", "--include-scores"),
+        action = 'store_true',
+        default = FALSE,
+        type = 'logical',
+        help = 'Should prediction scores be included in output? Default: FALSE'
+    ), 
+    make_option(
+        c("-k", "--sim-col-name"),
+        action = 'store',
+        default = 'scmap_cluster_siml',
+        type = 'character',
+        help = 'Column name of similarity scores'
+    )
+)
+
+opt = wsc_parse_args(option_list, mandatory = c("predictions_file", "output_table"))
+data = read.csv(file=opt$predictions_file)
+output = data[, c('cell', 'combined_labs')]
+# provide scores if specified
+if(!is.na(opt$include_scores)){
+    score = as.character(data[, opt$sim_col_name])
+    output = cbind(output, score)
+    col_names = c("cell_id", "predicted_label", "score")
+} else{
+    col_names = c("cell_id", "predicted_label")
+}
+colnames(output) = col_names
+write.table(output, file = opt$output_table, sep="\t", row.names=FALSE)


### PR DESCRIPTION
This PR will prepare the repo for a new release, which will be required for running Nextflow pipelines of different types.  

`scmap_get_std_output.R` is useful when scmap-cli is incorporated into Nextflow pipelines. It allows to programmatically extract output data in a standardised format, facilitating downstream analyses.