### PR TITLE
add dataset tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ Here we generate a summary representation of each cluster in the indexed dataset
 ```
 scmap-index-cluster.R --input-object-file <input SingleCellExperiment in .rds format> \
      --cluster-col <column name where cell types are stored> \
-    --output-object-file <output SingleCellExperiment in .rds format> \
-    --output-plot-file <optional file name in .png format, for heatmap-style index visualisation>
+     --train-idf <Path to the training data IDF file (optional)> \
+     --output-object-file <output SingleCellExperiment in .rds format> \
+     --output-plot-file <optional file name in .png format, for heatmap-style index visualisation>
 ```
 
 ### Project one dataset to another 
@@ -58,6 +59,7 @@ Here we generate a cell-wise index:
 
 ```
 scmap-index-cell.R --input-object-file <input SingleCellExperiment in .rds format> \
+    --train-idf <Path to the training data IDF file (optional)> \
     --number-chunks <number of chunks into which the expr matrix is split> \
     --number-clusters <number of clusters per group for k-means clustering> \
     --output-object-file <output SingleCellExperiment in .rds format>
@@ -84,6 +86,8 @@ scmap_get_std_output.R\
             --predictions-file <Path to the predictions file in text format>\
             --output-table <Path to the final output file in text format>\
             --include-scores <Boolean: Should prediction scores be included in output? Default: FALSE>\
+            --tool <What tool produced output? (scmap-cell or scmap-cluster)>\
+            --index <Path to the index object in .rds format (Optional; required to add dataset of origin to output table)>\
             --sim-col-name <Column name of similarity scores>
 ```
 

--- a/scmap-cli-post-install-tests.bats
+++ b/scmap-cli-post-install-tests.bats
@@ -52,7 +52,7 @@
         skip "$index_cluster_sce exists and use_existing_outputs is set to 'true'"
     fi
    
-    run rm -f $index_cluster_sce && scmap-index-cluster.R --input-object-file $select_features_sce --cluster-col $cluster_col --output-object-file $index_cluster_sce --output-plot-file $index_cluster_plot
+    run rm -f $index_cluster_sce && scmap-index-cluster.R --input-object-file $select_features_sce --cluster-col $cluster_col --train-idf $train_idf --output-object-file $index_cluster_sce --output-plot-file $index_cluster_plot
 
     echo "status = ${status}"
     echo "output = ${output}"
@@ -83,6 +83,7 @@
     run rm -f $index_cell_sce && scmap-index-cell.R\
                                  --input-object-file $select_features_sce\
                                  --output-object-file $index_cell_sce\
+                                 --train-idf $train_idf\
                                  --number-chunks $cells_number_chunks\
                                  --number-clusters $cells_number_clusters\
                                  --random-seed $random_seed
@@ -117,6 +118,8 @@
     run rm -rf $scmap_output_tbl && scmap_get_std_output.R\
                                         --predictions-file $closest_cells_clusters_csv\
                                         --output-table $scmap_output_tbl\
+                                        --index $index_cluster_sce\
+                                        --tool 'scmap-cell'\
                                         --include-scores
 
     echo "status = ${status}"

--- a/scmap-cli-post-install-tests.sh
+++ b/scmap-cli-post-install-tests.sh
@@ -53,6 +53,7 @@ mkdir -p $output_dir
 ################################################################################
 
 export test_sce=$output_dir'/test_sce.rds'
+export train_idf=$test_working_dir/'E-ENAD-16.idf.txt'
 export test_sce_processed=$output_dir'/test_sce_processed.rds'
 export select_features_sce=$output_dir'/select_features.rds'
 export select_features_plot=$output_dir'/select_features.png'
@@ -91,6 +92,9 @@ export cell_number_nearest_neighbours=5
 # where one of a chain has completed successfullly.
 
 export use_existing_outputs
+
+# Import IDF file 
+wget "ftp://ftp.ebi.ac.uk/pub/databases/microarray/data/atlas/sc_experiments/E-ENAD-16/E-ENAD-16.idf.txt" -P $test_working_dir
 
 # Derive the tests file name from the script name
 

--- a/scmap-index-cell.R
+++ b/scmap-index-cell.R
@@ -32,6 +32,13 @@ option_list = list(
     help = 'Number of clusters per group for k-means clustering.'
   ),
   make_option(
+    c("-f", "--train-idf"), 
+    action = "store",
+    default = NA,
+    type = 'character',
+    help = 'Path to the training data IDF file (optional)'
+  ),
+  make_option(
     c("-r", "--random-seed"),
     action = "store",
     default = NULL,
@@ -76,6 +83,16 @@ if (is.null(opt$random_seed)){
 
 # Run indexing function
 SingleCellExperiment <- indexCell(SingleCellExperiment, M = opt$number_chunks, k = opt$number_clusters)
+
+# add dataset field to the SingleCellExperiment object 
+if(!is.na(opt$train_idf)){
+    idf = readLines(opt$train_idf)
+    L = idf[grep("ExpressionAtlasAccession", idf)]
+    dataset = unlist(strsplit(L, "\\t"))[2]
+    attributes(SingleCellExperiment)$dataset = dataset
+    } else{
+        attributes(SingleCellExperiment)$dataset = NA
+    }
 
 # Print introspective information
 cat(capture.output(SingleCellExperiment), sep='\n')

--- a/scmap-index-cluster.R
+++ b/scmap-index-cluster.R
@@ -25,6 +25,13 @@ option_list = list(
     help = "Column name in the 'colData' slot of the SingleCellExperiment object containing the cell classification information."
   ),
   make_option(
+    c("-f", "--train-idf"), 
+    action = "store",
+    default = NA,
+    type = 'character',
+    help = 'Path to the training data IDF file (optional)'
+  ),
+  make_option(
     c("-p", "--output-plot-file"),
     action = "store",
     default = NA,
@@ -63,6 +70,16 @@ if (! is.na(opt$output_plot_file)){
   heatmap(as.matrix(metadata(SingleCellExperiment)$scmap_cluster_index))
   dev.off()
 }
+
+# add dataset field to the SingleCellExperiment object 
+if(!is.na(opt$train_idf)){
+    idf = readLines(opt$train_idf)
+    L = idf[grep("ExpressionAtlasAccession", idf)]
+    dataset = unlist(strsplit(L, "\\t"))[2]
+    attributes(SingleCellExperiment)$dataset = dataset
+    } else{
+        attributes(SingleCellExperiment)$dataset = NA
+    }
 
 # Print introspective information
 cat(capture.output(SingleCellExperiment), sep='\n')


### PR DESCRIPTION
- To avoid problems with Galaxy tools, remove dependency on file naming patters
- Track dataset of origin using an attribute of index object 
- Add metadata fields to the output tables