### PR TITLE
Switch csv delimiters to tsv

### DIFF
--- a/scmap-cli-post-install-tests.bats
+++ b/scmap-cli-post-install-tests.bats
@@ -66,7 +66,7 @@
         skip "$project_sce exists and use_existing_outputs is set to 'true'"
     fi
 
-    run rm -rf $project_sce && scmap-scmap-cluster.R -i $index_cluster_sce -p $test_sce_processed --threshold $cluster_similarity_threshold --output-text-file $project_csv --output-object-file $project_sce
+    run rm -rf $project_sce && scmap-scmap-cluster.R -i $index_cluster_sce -p $test_sce_processed --threshold $cluster_similarity_threshold --output-text-file $project_tsv --output-object-file $project_sce
 
     echo "status = ${status}"
     echo "output = ${output}"
@@ -100,7 +100,7 @@
         skip "$closest_cells_similarities_text_file exists and use_existing_outputs is set to 'true'"
     fi
 
-    run rm -rf $closest_cells_similarities_text_file && scmap-scmap-cell.R -i $index_cell_sce -p $test_sce_processed --number-nearest-neighbours $cell_number_nearest_neighbours --cluster-col $cluster_col --output-object-file $closest_cells_clusters_sce --output-clusters-text-file $closest_cells_clusters_csv --closest-cells-text-file $closest_cells_text_file --closest-cells-similarities-text-file $closest_cells_similarities_text_file
+    run rm -rf $closest_cells_similarities_text_file && scmap-scmap-cell.R -i $index_cell_sce -p $test_sce_processed --number-nearest-neighbours $cell_number_nearest_neighbours --cluster-col $cluster_col --output-object-file $closest_cells_clusters_sce --output-clusters-text-file $closest_cells_clusters_tsv --closest-cells-text-file $closest_cells_text_file --closest-cells-similarities-text-file $closest_cells_similarities_text_file
 
     echo "status = ${status}"
     echo "output = ${output}"
@@ -116,7 +116,7 @@
     fi
 
     run rm -rf $scmap_output_tbl && scmap_get_std_output.R\
-                                        --predictions-file $closest_cells_clusters_csv\
+                                        --predictions-file $closest_cells_clusters_tsv\
                                         --output-table $scmap_output_tbl\
                                         --index $index_cluster_sce\
                                         --tool 'scmap-cell'\

--- a/scmap-cli-post-install-tests.sh
+++ b/scmap-cli-post-install-tests.sh
@@ -60,14 +60,14 @@ export select_features_plot=$output_dir'/select_features.png'
 export index_cluster_sce=$output_dir'/index_cluster.rds'
 export index_cluster_plot=$output_dir'/index_cluster.png'
 export project_sce=$output_dir'/project_cluster.rds'
-export project_csv=$output_dir'/project_cluster.csv'
+export project_tsv=$output_dir'/project_cluster.tsv'
 
 export index_cell_sce=$output_dir'/index_cell.rds'
 export project_cell_sce=$output_dir'/project_cell.rds'
-export closest_cells_text_file=$output_dir'/closest_cells.csv'
-export closest_cells_similarities_text_file=$output_dir'/closest_cells_similarities.csv'
+export closest_cells_text_file=$output_dir'/closest_cells.tsv'
+export closest_cells_similarities_text_file=$output_dir'/closest_cells_similarities.tsv'
 export closest_cells_clusters_sce=$output_dir'/closest_cells_clusters.rds'
-export closest_cells_clusters_csv=$output_dir'/closest_cells_clusters.csv'
+export closest_cells_clusters_tsv=$output_dir'/closest_cells_clusters.tsv'
 export scmap_output_tbl=$output_dir'/scmap_output_tbl.txt'
 
 ## Test parameters- would form config file in real workflow. DO NOT use these

--- a/scmap-scmap-cell.R
+++ b/scmap-scmap-cell.R
@@ -121,7 +121,7 @@ if (opt$cluster_col %in% colnames(colData(index_sce))){
   colData(project_sce) <- cbind(colData(project_sce), scmapCell_clusters)
   
   # Output assignments to a text format
-  write.csv(cbind(cell = colnames(project_sce), scmapCell_clusters), file=opt$output_clusters_text_file, quote = FALSE, row.names = FALSE)
+  write.table(cbind(cell = colnames(project_sce), scmapCell_clusters), file=opt$output_clusters_text_file, sep = "\t", quote = FALSE, row.names = FALSE)
 }
 
 # Output to a serialized R object if specified
@@ -145,5 +145,5 @@ scmapCell_results <- data.frame(do.call(cbind, lapply(scmapCell_results, functio
 cat(capture.output(project_sce), sep='\n')
 
 # Output assignments to a text format
-write.csv(scmapCell_results[[1]]$cells, file=opt$closest_cells_text_file, quote = FALSE)
-write.csv(scmapCell_results[[1]]$similarities, file=opt$closest_cells_similarities_text_file, quote = FALSE)
+write.table(scmapCell_results[[1]]$cells, file=opt$closest_cells_text_file, sep = "\t", quote = FALSE)
+write.table(scmapCell_results[[1]]$similarities, file=opt$closest_cells_similarities_text_file, sep = "\t", quote = FALSE)

--- a/scmap-scmap-cluster.R
+++ b/scmap-scmap-cluster.R
@@ -93,7 +93,7 @@ colData(project_sce) <- cbind(colData(project_sce), scmapCluster_results)
 cat(capture.output(project_sce), sep='\n')
 
 # Output assignments to a text format
-write.csv(cbind(cell = colnames(project_sce), scmapCluster_results), file=opt$output_text_file, quote = FALSE)
+write.table(cbind(cell = colnames(project_sce), scmapCluster_results), file=opt$output_text_file, sep = "\t", quote = FALSE)
 
 # Output to a serialized R object
 saveRDS(project_sce, file = opt$output_object_file)

--- a/scmap_get_std_output.R
+++ b/scmap_get_std_output.R
@@ -50,7 +50,7 @@ option_list = list(
 
 
 opt = wsc_parse_args(option_list, mandatory = c("predictions_file", "output_table", "tool"))
-data = read.csv(file=opt$predictions_file)
+data = read.csv(file=opt$predictions_file, sep = "\t", stringsAsFactors = FALSE)
 output = data[, c('cell', 'combined_labs')]
 # provide scores if specified
 if(!is.na(opt$include_scores)){


### PR DESCRIPTION
This PR changes `csv` outputs to `tsv` to avoid parsing problems when commas are present in cell types. 