### PR TITLE
Add option to remove expression data from indices

### DIFF
--- a/scmap-cli-post-install-tests.bats
+++ b/scmap-cli-post-install-tests.bats
@@ -52,7 +52,7 @@
         skip "$index_cluster_sce exists and use_existing_outputs is set to 'true'"
     fi
    
-    run rm -f $index_cluster_sce && scmap-index-cluster.R --input-object-file $select_features_sce --cluster-col $cluster_col --train-id $train_id --output-object-file $index_cluster_sce --output-plot-file $index_cluster_plot
+    run rm -f $index_cluster_sce && scmap-index-cluster.R --input-object-file $select_features_sce --cluster-col $cluster_col --remove-mat $remove_mat --train-id $train_id --output-object-file $index_cluster_sce --output-plot-file $index_cluster_plot
 
     echo "status = ${status}"
     echo "output = ${output}"
@@ -84,6 +84,7 @@
                                  --input-object-file $select_features_sce\
                                  --output-object-file $index_cell_sce\
                                  --train-id $train_id\
+                                 --remove-mat $remove_mat\
                                  --number-chunks $cells_number_chunks\
                                  --number-clusters $cells_number_clusters\
                                  --random-seed $random_seed

--- a/scmap-cli-post-install-tests.sh
+++ b/scmap-cli-post-install-tests.sh
@@ -78,6 +78,7 @@ export scmap_output_tbl=$output_dir'/scmap_output_tbl.txt'
 export n_features=500
 export cluster_col='cell_type1'
 export cluster_similarity_threshold=0.7
+export remove_mat="TRUE"
 
 export random_seed=1
 export cells_number_chunks=50

--- a/scmap-index-cell.R
+++ b/scmap-index-cell.R
@@ -39,6 +39,13 @@ option_list = list(
     help = 'ID of the training dataset (optional)'
   ),
   make_option(
+    c("-e", "--remove-mat"), 
+    action = "store_true",
+    default = FALSE,
+    type = 'logical',
+    help = 'Should expression data be removed from index object? Default: FALSE'
+  ),
+  make_option(
     c("-r", "--random-seed"),
     action = "store",
     default = NULL,
@@ -82,13 +89,23 @@ if (is.null(opt$random_seed)){
 }
 
 # Run indexing function
-SingleCellExperiment <- indexCell(SingleCellExperiment, M = opt$number_chunks, k = opt$number_clusters)
+SingleCellExperiment <- indexCell(SingleCellExperiment, M = opt$number_chunks,
+                                                        k = opt$number_clusters)
 
 # add dataset field to the SingleCellExperiment object 
 if(!is.na(opt$train_id)){
     attributes(SingleCellExperiment)$dataset = opt$train_id
     } else{
         attributes(SingleCellExperiment)$dataset = NA
+}
+
+# Remove expression matrix, if specified
+if(opt$remove_mat){
+    for(assay_type in c('counts', 'normcounts', 'logcounts')){
+        if(assay_type %in% names(assays(SingleCellExperiment))){
+            assays(SingleCellExperiment)[assay_type] = NULL
+        }
+    } 
 }
 
 # Print introspective information

--- a/scmap-index-cluster.R
+++ b/scmap-index-cluster.R
@@ -32,6 +32,13 @@ option_list = list(
     help = 'ID of the training dataset (optional)'
   ),
   make_option(
+    c("-r", "--remove-mat"), 
+    action = "store_true",
+    default = FALSE,
+    type = 'logical',
+    help = 'Should expression data be removed from index object? Default: FALSE'
+  ),
+  make_option(
     c("-p", "--output-plot-file"),
     action = "store",
     default = NA,
@@ -77,6 +84,15 @@ if(!is.na(opt$train_id)){
     } else{
         attributes(SingleCellExperiment)$dataset = NA
     }
+
+# Remove expression matrix, if specified
+if(opt$remove_mat){
+    for(assay_type in c('counts', 'normcounts', 'logcounts')){
+        if(assay_type %in% names(assays(SingleCellExperiment))){
+            assays(SingleCellExperiment)[assay_type] = NULL
+        }
+    } 
+}
 
 # Print introspective information
 cat(capture.output(SingleCellExperiment), sep='\n')


### PR DESCRIPTION
The index-generating step in `scmap` returns an SCE object that also contains the expression data in the `assays()` slot. For large datasets, this might lead to classifiers that are several gigabytes in size, causing problems with data transfer and storage. This PR addresses this problem and adds logic that allows to remove expression data from the indices. 