### PR TITLE
Utilise unused parameters

### DIFF
--- a/scmap-scmap-cluster.R
+++ b/scmap-scmap-cluster.R
@@ -73,7 +73,8 @@ scmapCluster_results <- scmapCluster(
   projection = project_sce, 
   index_list = list(
     metadata(index_sce)$scmap_cluster_index
-  )
+  ),
+  threshold = opt$threshold
 )
 
 # Output format anticipates multiple input indexes, let's assume a single input

--- a/scmap-select-features.R
+++ b/scmap-select-features.R
@@ -55,10 +55,10 @@ if ( ! file.exists(opt$input_object_file)){
 SingleCellExperiment <- readRDS(opt$input_object_file)
 
 if (is.na(opt$output_plot_file)){
-  SingleCellExperiment <- selectFeatures(SingleCellExperiment, suppress_plot = TRUE)
+  SingleCellExperiment <- selectFeatures(SingleCellExperiment, n_features = opt$n_features, suppress_plot = TRUE)
 }else{
   png(file = opt$output_plot_file)
-  SingleCellExperiment <- selectFeatures(SingleCellExperiment, suppress_plot = FALSE)
+  SingleCellExperiment <- selectFeatures(SingleCellExperiment, n_features = opt$n_features, suppress_plot = FALSE)
   dev.off()
 }
 


### PR DESCRIPTION
Makes use of the ```threshold``` and ```n_features``` parameters that are present in the tools but not used in the scripts. 

Fixes some issues raised in https://github.com/galaxyproject/tools-iuc/issues/5444#issue-1854718102